### PR TITLE
lock docker version to 1.12.6 to lvm driver and set ip forwarding

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -7,4 +7,4 @@
 # All rights reserved - Do Not Redistribute
 #
 
-default["base2-docker"]["docker_version"]["amazon"]["2016.09"] = "1.12.6-2.19.amzn1"
+default["base2-docker"]["docker"]["version"] = "1.12.6-2.19.amzn1"

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -8,7 +8,7 @@
 #
 
 execute "Set IP Forwarding" do
-  command "echo 1 > /proc/sys/net/ipv4/ip_forward"
+  command "sed -i -E \"s/^ *net.ipv4.ip_forward += +.*$/net.ipv4.ip_forward = 1/g\" /etc/sysctl.conf"
   action :run
 end
 

--- a/recipes/storage_direct_lvm.rb
+++ b/recipes/storage_direct_lvm.rb
@@ -31,6 +31,7 @@ execute "apply_lvm_profile" do
 end
 
 docker_service "default" do
+  version node["base2-docker"]["docker"]["version"]
   storage_opts [
     "dm.thinpooldev=/dev/mapper/docker-thinpool",
     "dm.use_deferred_removal=true",

--- a/recipes/storage_direct_lvm.rb
+++ b/recipes/storage_direct_lvm.rb
@@ -11,7 +11,7 @@
 # NOTE: requires an additional EBS volume
 
 execute "Set IP Forwarding" do
-  command "echo 1 > /proc/sys/net/ipv4/ip_forward"
+  command "sed -i -E \"s/^ *net.ipv4.ip_forward += +.*$/net.ipv4.ip_forward = 1/g\" /etc/sysctl.conf"
   action :run
 end
 

--- a/recipes/storage_overlay2.rb
+++ b/recipes/storage_overlay2.rb
@@ -10,7 +10,7 @@
 # This uses the overlay2 stroage driver
 
 execute "Set IP Forwarding" do
-  command "echo 1 > /proc/sys/net/ipv4/ip_forward"
+  command "sed -i -E \"s/^ *net.ipv4.ip_forward += +.*$/net.ipv4.ip_forward = 1/g\" /etc/sysctl.conf"
   action :run
 end
 


### PR DESCRIPTION
Changes
* Locking docker version to 1.12.6 for direct lvm driver. Overlay 2 will use the latest 17.0.6 CE
* Setting a fixed ip forwarding to 1 as we restart the network during userdata to set hostname.
